### PR TITLE
CCS-34: Fix logout/darkmode/settings menu opening on sign in

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -57,6 +57,7 @@ export default function Layout() {
   };
 
   const handleLogout = () => {
+    setAnchorElUser(null); // Resetting menu state
     localStorage.removeItem("token");
     localStorage.removeItem("userRole");
     navigate("/");


### PR DESCRIPTION
Menu no longer opens on subsequent logins (after first one).